### PR TITLE
Remove green dot from SA logo

### DIFF
--- a/src/app/(site)/blog/[slug]/opengraph-image.tsx
+++ b/src/app/(site)/blog/[slug]/opengraph-image.tsx
@@ -37,14 +37,6 @@ export default async function OpengraphImage({
         }}>
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
           <span style={{ fontSize: 40, fontWeight: 700 }}>SA</span>
-          <span
-            style={{
-              width: 14,
-              height: 14,
-              borderRadius: 9999,
-              backgroundColor: "#34d399",
-            }}
-          />
           <span style={{ fontSize: 28, color: "#a3a3a3", marginLeft: 16 }}>
             sixtusagbo.dev/blog
           </span>

--- a/src/app/admin/(panel)/layout.tsx
+++ b/src/app/admin/(panel)/layout.tsx
@@ -24,7 +24,6 @@ export default async function AdminLayout({
         <div className="flex md:flex-col items-center md:items-stretch gap-4 md:gap-8 flex-1 min-w-0">
           <Link href="/admin" className="text-2xl font-bold tracking-tighter px-2">
             SA
-            <span className="inline-block w-2 h-2 bg-emerald-400 rounded-full ml-1" />
           </Link>
           <AdminNav />
         </div>

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -17,7 +17,6 @@ export default async function LoginPage() {
         <div className="space-y-2 text-center">
           <span className="text-2xl font-bold tracking-tighter">
             SA
-            <span className="inline-block w-2 h-2 bg-emerald-400 rounded-full ml-1" />
           </span>
           <h1 className="text-2xl font-bold">Admin Panel</h1>
           <p className="text-sm text-neutral-400">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -12,7 +12,6 @@ export default function Footer() {
           <div className="space-y-4">
             <span className="text-2xl font-bold tracking-tighter">
               SA
-              <span className="inline-block w-2 h-2 bg-emerald-400 rounded-full ml-1" />
             </span>
             <p className="text-neutral-400 text-sm leading-relaxed">
               Full-Stack Developer crafting exceptional digital experiences.

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -112,7 +112,6 @@ export default function Navigation() {
           <Link href="/" className="relative z-10 group">
             <span className="text-2xl font-bold tracking-tighter">
               SA
-              <span className="inline-block w-2 h-2 bg-emerald-400 rounded-full ml-1 group-hover:animate-ping" />
             </span>
           </Link>
 


### PR DESCRIPTION
Removes the emerald accent dot from the SA logo everywhere it appears: nav bar (and its hover pulse), footer, admin panel sidebar, admin login, and the dynamic OG image. Other emerald usages (status badges, reading progress bar, copy confirmation) are unrelated and left intact.