### PR TITLE
Flag missing cover image before publishing

### DIFF
--- a/src/components/admin/PostEditor.tsx
+++ b/src/components/admin/PostEditor.tsx
@@ -97,6 +97,13 @@ export default function PostEditor({ post }: { post?: BlogPost }) {
   };
 
   const save = () => {
+    // Nudge for a cover image before publishing (drafts can skip it)
+    if (status === "published" && !coverImage.trim()) {
+      const proceed = window.confirm(
+        "Publish without a cover image? Posts look much better with one."
+      );
+      if (!proceed) return;
+    }
     setError("");
     startSaving(async () => {
       const result = await savePostAction({


### PR DESCRIPTION
When publishing a post (status published) with no cover image, the editor now asks for confirmation before saving, a Medium-style nudge so posts get a cover. Drafts are unaffected.