### PR TITLE
Delete a post's Cloudinary images on delete and on edit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,9 @@ ADMIN_PASSWORD=
 # When unset, the editor falls back to pasting an image URL.
 NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=
 NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET=
+
+# Cloudinary API key/secret (server-side only, add to Vercel as server env).
+# Enables auto-deleting a post's images from Cloudinary when you delete or
+# edit the post. When unset, image cleanup silently no-ops.
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.3",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.20",
+        "cloudinary": "^2.10.0",
         "framer-motion": "^12.26.2",
         "jose": "^6.2.3",
         "lucide-react": "^0.562.0",
@@ -31,7 +32,6 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "cloudinary": "^2.10.0",
         "eslint": "^9",
         "eslint-config-next": "16.1.2",
         "fast-xml-parser": "^5.8.0",
@@ -3308,7 +3308,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.10.0.tgz",
       "integrity": "sha512-sY09kYg7wprkndAOjZBAYqFZqwL+SxnEGcAvksOvFA+5upnFn949UjkEkHKNSwkBtW/xRDd0p6NgbSXZcxkI3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.23"
@@ -6103,7 +6102,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.20",
+    "cloudinary": "^2.10.0",
     "framer-motion": "^12.26.2",
     "jose": "^6.2.3",
     "lucide-react": "^0.562.0",
@@ -32,7 +33,6 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "cloudinary": "^2.10.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.2",
     "fast-xml-parser": "^5.8.0",

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -12,11 +12,26 @@ import {
   createPost,
   deletePost,
   getPostById,
+  imagesReferencedByOtherPosts,
   isSlugTaken,
   updatePost,
   type PostInput,
 } from "@/lib/posts";
 import { renderMarkdown } from "@/lib/markdown";
+import {
+  deleteCloudinaryImages,
+  findCloudinaryUrls,
+} from "@/lib/cloudinary-server";
+
+// Delete the given Cloudinary images, skipping any still used by another post.
+async function cleanupImages(
+  urls: string[],
+  excludeId?: string
+): Promise<void> {
+  if (urls.length === 0) return;
+  const stillUsed = await imagesReferencedByOtherPosts(urls, excludeId);
+  await deleteCloudinaryImages(urls.filter((u) => !stillUsed.has(u)));
+}
 
 export type FormState = { error: string } | null;
 
@@ -79,6 +94,18 @@ export async function savePostAction(
       : await createPost(payload);
     if (!saved) return { ok: false, error: "Post not found." };
 
+    // On edit, remove images that were dropped from the cover/content.
+    if (previous) {
+      const newUrls = new Set(
+        findCloudinaryUrls(saved.coverImage, saved.content)
+      );
+      const removed = findCloudinaryUrls(
+        previous.coverImage,
+        previous.content
+      ).filter((u) => !newUrls.has(u));
+      await cleanupImages(removed, saved.id);
+    }
+
     revalidateBlog([saved.slug, previous?.slug]);
     return { ok: true, id: saved.id, slug: saved.slug };
   } catch (error) {
@@ -104,7 +131,10 @@ export async function checkSlugAction(
 export async function deletePostAction(id: string): Promise<void> {
   await requireAdmin();
   const deleted = await deletePost(id);
-  if (deleted) revalidateBlog([deleted.slug]);
+  if (deleted) {
+    await cleanupImages(findCloudinaryUrls(deleted.coverImage, deleted.content));
+    revalidateBlog([deleted.slug]);
+  }
 }
 
 export async function setPostStatusAction(

--- a/src/lib/cloudinary-server.ts
+++ b/src/lib/cloudinary-server.ts
@@ -1,0 +1,55 @@
+import "server-only";
+import { v2 as cloudinary } from "cloudinary";
+
+const CLOUD_NAME =
+  process.env.CLOUDINARY_CLOUD_NAME ??
+  process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+const API_KEY = process.env.CLOUDINARY_API_KEY;
+const API_SECRET = process.env.CLOUDINARY_API_SECRET;
+
+// Deletes are signed operations, so they need the API key + secret on the
+// server. When those are absent, cleanup silently no-ops (delete still works).
+const cleanupEnabled = Boolean(CLOUD_NAME && API_KEY && API_SECRET);
+
+if (cleanupEnabled) {
+  cloudinary.config({
+    cloud_name: CLOUD_NAME,
+    api_key: API_KEY,
+    api_secret: API_SECRET,
+  });
+}
+
+/** Pull the Cloudinary public_id out of a delivery URL, or null if not ours. */
+export function cloudinaryPublicId(url: string): string | null {
+  const match = url.match(
+    /res\.cloudinary\.com\/[^/]+\/image\/upload\/(?:v\d+\/)?(.+?)\.[a-z0-9]+(?:[?#].*)?$/i
+  );
+  return match ? match[1] : null;
+}
+
+/** Find every Cloudinary image URL inside the given text blobs. */
+export function findCloudinaryUrls(...texts: (string | undefined | null)[]): string[] {
+  const urls = new Set<string>();
+  const rx = /https?:\/\/res\.cloudinary\.com\/[^\s"')]+/g;
+  for (const text of texts) {
+    for (const match of (text ?? "").matchAll(rx)) urls.add(match[0]);
+  }
+  return [...urls];
+}
+
+/** Delete the given Cloudinary image URLs. Best-effort, never throws. */
+export async function deleteCloudinaryImages(urls: string[]): Promise<void> {
+  if (!cleanupEnabled || urls.length === 0) return;
+  const ids = urls
+    .map(cloudinaryPublicId)
+    .filter((id): id is string => Boolean(id));
+  await Promise.all(
+    ids.map((id) =>
+      cloudinary.uploader
+        .destroy(id, { invalidate: true })
+        .catch(() => {
+          // image cleanup must never break the delete/save flow
+        })
+    )
+  );
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -298,3 +298,32 @@ export async function isSlugTaken(
   if (excludeId) filter._id = { $ne: excludeId };
   return (await Post.exists(filter)) !== null;
 }
+
+// Of the given image URLs, which are still used by some other post (so they
+// must not be deleted from Cloudinary).
+export async function imagesReferencedByOtherPosts(
+  urls: string[],
+  excludeId?: string
+): Promise<Set<string>> {
+  await connectDB();
+  if (urls.length === 0) return new Set();
+  const filter: QueryFilter<PostDoc> = {
+    $or: urls.flatMap((url) => [
+      { coverImage: url },
+      { content: { $regex: escapeRegExp(url) } },
+    ]),
+  };
+  if (excludeId) filter._id = { $ne: excludeId };
+  const docs = await Post.find(filter)
+    .select("coverImage content")
+    .lean<LeanPost[]>();
+  const referenced = new Set<string>();
+  for (const url of urls) {
+    if (
+      docs.some((d) => d.coverImage === url || (d.content ?? "").includes(url))
+    ) {
+      referenced.add(url);
+    }
+  }
+  return referenced;
+}


### PR DESCRIPTION
When a post is deleted, its Cloudinary cover + inline images are removed too. When a post is edited, images dropped from the cover/content are removed. A cross-reference check skips any image still used by another post. Signed deletes need CLOUDINARY_API_KEY + CLOUDINARY_API_SECRET in the server env (add to Vercel); without them, cleanup silently no-ops and delete/edit still work.