### PR TITLE
Add Unsplash image picker to the admin editor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET=
 # edit the post. When unset, image cleanup silently no-ops.
 CLOUDINARY_API_KEY=
 CLOUDINARY_API_SECRET=
+
+# Unsplash access key (server-side only) - enables the Unsplash image picker in
+# the admin editor. Register a free app at unsplash.com/developers.
+# When unset, the Unsplash buttons are hidden.
+UNSPLASH_ACCESS_KEY=

--- a/src/app/admin/(panel)/posts/[id]/page.tsx
+++ b/src/app/admin/(panel)/posts/[id]/page.tsx
@@ -20,5 +20,10 @@ export default async function EditPostPage({
   }
   if (!post) notFound();
 
-  return <PostEditor post={post} />;
+  return (
+    <PostEditor
+      post={post}
+      unsplashEnabled={Boolean(process.env.UNSPLASH_ACCESS_KEY)}
+    />
+  );
 }

--- a/src/app/admin/(panel)/posts/new/page.tsx
+++ b/src/app/admin/(panel)/posts/new/page.tsx
@@ -4,5 +4,5 @@ import PostEditor from "@/components/admin/PostEditor";
 export const metadata: Metadata = { title: "New Post" };
 
 export default function NewPostPage() {
-  return <PostEditor />;
+  return <PostEditor unsplashEnabled={Boolean(process.env.UNSPLASH_ACCESS_KEY)} />;
 }

--- a/src/app/api/unsplash/search/route.ts
+++ b/src/app/api/unsplash/search/route.ts
@@ -1,0 +1,55 @@
+import { isAuthenticated } from "@/lib/auth";
+
+const KEY = process.env.UNSPLASH_ACCESS_KEY;
+// utm_source must match your registered Unsplash app name (their API guideline).
+const APP = "sixtusagbo-blog";
+
+type UnsplashPhoto = {
+  id: string;
+  urls: { small: string; regular: string };
+  alt_description: string | null;
+  description: string | null;
+  user: { name: string; links: { html: string } };
+  links: { download_location: string };
+};
+
+export async function GET(request: Request) {
+  if (!(await isAuthenticated())) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  if (!KEY) {
+    return Response.json({ error: "Unsplash is not configured" }, { status: 503 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const q = (searchParams.get("q") ?? "").trim();
+  const page = searchParams.get("page") ?? "1";
+  if (!q) return Response.json({ results: [], totalPages: 0 });
+
+  const api = `https://api.unsplash.com/search/photos?query=${encodeURIComponent(
+    q
+  )}&page=${page}&per_page=24&content_filter=high`;
+
+  const res = await fetch(api, {
+    headers: { Authorization: `Client-ID ${KEY}`, "Accept-Version": "v1" },
+  });
+  if (!res.ok) {
+    return Response.json({ error: "Unsplash request failed" }, { status: 502 });
+  }
+
+  const data = (await res.json()) as {
+    results: UnsplashPhoto[];
+    total_pages: number;
+  };
+  const results = data.results.map((p) => ({
+    id: p.id,
+    thumb: p.urls.small,
+    url: p.urls.regular,
+    alt: p.alt_description ?? p.description ?? "",
+    author: p.user?.name ?? "Unknown",
+    authorUrl: `${p.user?.links?.html}?utm_source=${APP}&utm_medium=referral`,
+    downloadLocation: p.links?.download_location,
+  }));
+
+  return Response.json({ results, totalPages: data.total_pages });
+}

--- a/src/app/api/unsplash/track/route.ts
+++ b/src/app/api/unsplash/track/route.ts
@@ -1,0 +1,23 @@
+import { isAuthenticated } from "@/lib/auth";
+
+const KEY = process.env.UNSPLASH_ACCESS_KEY;
+
+// Unsplash API guideline: trigger the photo's download endpoint when a user
+// actually uses (selects) it. Fire-and-forget.
+export async function POST(request: Request) {
+  if (!(await isAuthenticated())) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  if (!KEY) return new Response(null, { status: 204 });
+
+  const { downloadLocation } = (await request
+    .json()
+    .catch(() => ({}))) as { downloadLocation?: string };
+
+  if (downloadLocation?.startsWith("https://api.unsplash.com/")) {
+    await fetch(downloadLocation, {
+      headers: { Authorization: `Client-ID ${KEY}` },
+    }).catch(() => {});
+  }
+  return new Response(null, { status: 204 });
+}

--- a/src/components/admin/PostEditor.tsx
+++ b/src/components/admin/PostEditor.tsx
@@ -3,19 +3,41 @@
 import { useEffect, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Eye, Loader2, PenLine, RefreshCw } from "lucide-react";
+import {
+  ArrowLeft,
+  Eye,
+  Image as ImageIcon,
+  Loader2,
+  PenLine,
+  RefreshCw,
+} from "lucide-react";
 import { previewMarkdownAction, savePostAction } from "@/app/admin/actions";
 import type { BlogPost } from "@/lib/posts";
 import { calculateReadingTime, slugify } from "@/lib/utils";
 import { cloudinaryConfigured } from "@/lib/cloudinary";
 import ImageUploadButton from "@/components/admin/ImageUploadButton";
+import UnsplashPicker, {
+  type UnsplashPick,
+} from "@/components/admin/UnsplashPicker";
+
+const UNSPLASH_HOME =
+  "https://unsplash.com/?utm_source=sixtusagbo-blog&utm_medium=referral";
+
+const unsplashBtnClass =
+  "inline-flex items-center gap-1.5 px-3 py-2 bg-neutral-800 border border-neutral-700 rounded-xl text-xs font-medium text-neutral-300 hover:text-white transition-colors";
 
 const inputClass =
   "w-full bg-neutral-800 border border-neutral-700 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:border-neutral-500 placeholder-neutral-500";
 
 const labelClass = "text-sm text-neutral-400";
 
-export default function PostEditor({ post }: { post?: BlogPost }) {
+export default function PostEditor({
+  post,
+  unsplashEnabled = false,
+}: {
+  post?: BlogPost;
+  unsplashEnabled?: boolean;
+}) {
   const router = useRouter();
 
   const [title, setTitle] = useState(post?.title ?? "");
@@ -34,6 +56,10 @@ export default function PostEditor({ post }: { post?: BlogPost }) {
   const [previewLoading, setPreviewLoading] = useState(false);
   const previewedContent = useRef<string | null>(null);
   const contentRef = useRef<HTMLTextAreaElement>(null);
+  const [unsplashMode, setUnsplashMode] = useState<null | "cover" | "inline">(
+    null
+  );
+  const showUnsplash = cloudinaryConfigured && unsplashEnabled;
 
   const [error, setError] = useState("");
   const [dirty, setDirty] = useState(false);
@@ -79,21 +105,43 @@ export default function PostEditor({ post }: { post?: BlogPost }) {
     });
   };
 
-  const insertImageMarkdown = (url: string) => {
-    const md = `![](${url})`;
+  const insertAtCursor = (text: string) => {
     const ta = contentRef.current;
     if (!ta) {
-      setContent((c) => `${c}\n${md}\n`);
+      setContent((c) => `${c}\n${text}\n`);
       markDirty();
       return;
     }
     const { selectionStart, selectionEnd, value } = ta;
-    setContent(value.slice(0, selectionStart) + md + value.slice(selectionEnd));
+    setContent(value.slice(0, selectionStart) + text + value.slice(selectionEnd));
     markDirty();
     requestAnimationFrame(() => {
       ta.focus();
-      ta.selectionStart = ta.selectionEnd = selectionStart + md.length;
+      ta.selectionStart = ta.selectionEnd = selectionStart + text.length;
     });
+  };
+
+  const insertImageMarkdown = (url: string) => insertAtCursor(`![](${url})`);
+
+  const handleUnsplashPick = (p: UnsplashPick) => {
+    if (unsplashMode === "cover") {
+      setCoverImage(p.url);
+      const line = `*Cover photo by [${p.author}](${p.authorUrl}) on [Unsplash](${UNSPLASH_HOME})*`;
+      // keep a single, deduped cover-credit line at the end of the content
+      setContent((c) => {
+        const cleaned = c
+          .replace(/\n*\*Cover photo by .*?\*\s*$/s, "")
+          .replace(/\s+$/, "");
+        return cleaned ? `${cleaned}\n\n${line}\n` : `${line}\n`;
+      });
+      markDirty();
+    } else {
+      const alt = p.alt.replace(/[[\]]/g, "");
+      insertAtCursor(
+        `![${alt}](${p.url})\n*Photo by [${p.author}](${p.authorUrl}) on [Unsplash](${UNSPLASH_HOME})*\n`
+      );
+    }
+    setUnsplashMode(null);
   };
 
   const save = () => {
@@ -227,14 +275,23 @@ export default function PostEditor({ post }: { post?: BlogPost }) {
               <Eye size={14} />
               Preview
             </button>
-            <div className="ml-auto flex items-center gap-3">
+            <div className="ml-auto flex items-center gap-2">
+              {showUnsplash && (
+                <button
+                  type="button"
+                  onClick={() => setUnsplashMode("inline")}
+                  className={unsplashBtnClass}>
+                  <ImageIcon size={14} />
+                  Unsplash
+                </button>
+              )}
               {cloudinaryConfigured && (
                 <ImageUploadButton
                   label="Insert image"
                   onUploaded={insertImageMarkdown}
                 />
               )}
-              <span className="text-xs text-neutral-500">
+              <span className="text-xs text-neutral-500 ml-1">
                 {words} words · {calculateReadingTime(content)} min read
               </span>
             </div>
@@ -328,15 +385,26 @@ export default function PostEditor({ post }: { post?: BlogPost }) {
               <label htmlFor="cover" className={labelClass}>
                 Cover image
               </label>
-              {cloudinaryConfigured && (
-                <ImageUploadButton
-                  label="Upload"
-                  onUploaded={(url) => {
-                    setCoverImage(url);
-                    markDirty();
-                  }}
-                />
-              )}
+              <div className="flex items-center gap-2">
+                {showUnsplash && (
+                  <button
+                    type="button"
+                    onClick={() => setUnsplashMode("cover")}
+                    className={unsplashBtnClass}>
+                    <ImageIcon size={14} />
+                    Unsplash
+                  </button>
+                )}
+                {cloudinaryConfigured && (
+                  <ImageUploadButton
+                    label="Upload"
+                    onUploaded={(url) => {
+                      setCoverImage(url);
+                      markDirty();
+                    }}
+                  />
+                )}
+              </div>
             </div>
             <input
               id="cover"
@@ -392,6 +460,13 @@ export default function PostEditor({ post }: { post?: BlogPost }) {
           </div>
         </div>
       </div>
+
+      {unsplashMode && (
+        <UnsplashPicker
+          onPick={handleUnsplashPick}
+          onClose={() => setUnsplashMode(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/admin/UnsplashPicker.tsx
+++ b/src/components/admin/UnsplashPicker.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Search, X } from "lucide-react";
+import { uploadUrlToCloudinary } from "@/lib/cloudinary";
+
+type Result = {
+  id: string;
+  thumb: string;
+  url: string;
+  alt: string;
+  author: string;
+  authorUrl: string;
+  downloadLocation: string;
+};
+
+export type UnsplashPick = {
+  url: string;
+  alt: string;
+  author: string;
+  authorUrl: string;
+};
+
+export default function UnsplashPicker({
+  onPick,
+  onClose,
+}: {
+  onPick: (pick: UnsplashPick) => void;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Result[]>([]);
+  const [searched, setSearched] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [pickingId, setPickingId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const search = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!query.trim()) return;
+    setLoading(true);
+    setError("");
+    setSearched(true);
+    try {
+      const res = await fetch(`/api/unsplash/search?q=${encodeURIComponent(query)}`);
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Search failed");
+        setResults([]);
+      } else {
+        setResults(data.results);
+      }
+    } catch {
+      setError("Search failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const pick = async (r: Result) => {
+    setPickingId(r.id);
+    setError("");
+    // Unsplash guideline: ping the download endpoint on use (fire-and-forget)
+    fetch("/api/unsplash/track", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ downloadLocation: r.downloadLocation }),
+    }).catch(() => {});
+    try {
+      const cloudUrl = await uploadUrlToCloudinary(r.url);
+      onPick({ url: cloudUrl, alt: r.alt, author: r.author, authorUrl: r.authorUrl });
+      onClose();
+    } catch {
+      setError("Could not import that image. Try another.");
+      setPickingId(null);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] bg-neutral-950/80 backdrop-blur-sm flex items-start justify-center p-4 sm:p-8 overflow-y-auto"
+      onClick={onClose}>
+      <div
+        className="w-full max-w-4xl bg-neutral-900 border border-neutral-800 rounded-3xl p-6 space-y-4"
+        onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between">
+          <h2 className="font-semibold">Search Unsplash</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 text-neutral-400 hover:text-white rounded-lg hover:bg-neutral-800 transition-colors">
+            <X size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={search} className="relative">
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500"
+          />
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search photos, then press Enter"
+            className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-10 py-2.5 text-sm focus:outline-none focus:border-neutral-500 placeholder-neutral-500"
+          />
+        </form>
+
+        {error && <p className="text-sm text-red-400">{error}</p>}
+
+        {loading ? (
+          <div className="flex justify-center py-16">
+            <Loader2 size={22} className="animate-spin text-neutral-500" />
+          </div>
+        ) : results.length > 0 ? (
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 max-h-[60vh] overflow-y-auto pr-1">
+            {results.map((r) => (
+              <button
+                key={r.id}
+                onClick={() => pick(r)}
+                disabled={pickingId !== null}
+                title={`Photo by ${r.author}`}
+                className="group relative aspect-video overflow-hidden rounded-xl bg-neutral-800 disabled:opacity-60">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={r.thumb}
+                  alt={r.alt}
+                  loading="lazy"
+                  className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                />
+                <span className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/70 to-transparent text-[10px] text-neutral-200 px-2 py-1 text-left truncate">
+                  {r.author}
+                </span>
+                {pickingId === r.id && (
+                  <span className="absolute inset-0 grid place-items-center bg-neutral-950/60">
+                    <Loader2 size={20} className="animate-spin" />
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        ) : (
+          searched && (
+            <p className="text-sm text-neutral-500 py-8 text-center">
+              No photos found. Try another search.
+            </p>
+          )
+        )}
+
+        <p className="text-xs text-neutral-500">
+          Photos from Unsplash. The photographer is credited automatically.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -5,7 +5,7 @@ const UPLOAD_PRESET = process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET;
 // upload UI and fall back to pasting a URL when Cloudinary isn't configured.
 export const cloudinaryConfigured = Boolean(CLOUD_NAME && UPLOAD_PRESET);
 
-export async function uploadToCloudinary(file: File): Promise<string> {
+async function upload(file: string | File): Promise<string> {
   if (!CLOUD_NAME || !UPLOAD_PRESET) {
     throw new Error("Cloudinary is not configured");
   }
@@ -23,4 +23,14 @@ export async function uploadToCloudinary(file: File): Promise<string> {
   const data = (await res.json()) as { secure_url?: string };
   if (!data.secure_url) throw new Error("Upload returned no URL");
   return data.secure_url;
+}
+
+export function uploadToCloudinary(file: File): Promise<string> {
+  return upload(file);
+}
+
+// Cloudinary's unsigned upload accepts a remote URL as the file, so it fetches
+// and stores the image (used to bring an Unsplash photo into your Cloudinary).
+export function uploadUrlToCloudinary(imageUrl: string): Promise<string> {
+  return upload(imageUrl);
 }


### PR DESCRIPTION
Adds a Medium-style Unsplash picker for cover and inline images. Search runs through a server route so my access key stays server-side (admin-gated); picking a photo fires Unsplash's download ping, uploads the image into my Cloudinary, and inserts it with automatic photographer attribution. Buttons show only when both Cloudinary and UNSPLASH_ACCESS_KEY are configured. I add UNSPLASH_ACCESS_KEY (free, from unsplash.com/developers) to .env.local and Vercel (server scope).