### PR TITLE
Keep filtered blog listings out of the search index

### DIFF
--- a/src/app/(site)/blog/page.tsx
+++ b/src/app/(site)/blog/page.tsx
@@ -40,12 +40,15 @@ export async function generateMetadata({
   if (page > 1) canonicalParams.set("page", String(page));
   const canonical = `/blog${canonicalParams.size ? `?${canonicalParams}` : ""}`;
 
+  // Filtered/paginated listings are thin, near-duplicate views of /blog. Keep
+  // them crawlable (so Google still finds the posts) but out of the index.
+  const isFiltered = Boolean(q || tag) || page > 1;
+
   return {
     title,
     description,
     alternates: { canonical },
-    // Search result pages should not be indexed
-    robots: q ? { index: false, follow: true } : undefined,
+    robots: isFiltered ? { index: false, follow: true } : undefined,
     openGraph: {
       type: "website",
       url: canonical,


### PR DESCRIPTION
My tag, search, and paginated blog listings (e.g. /blog?tag=React, /blog?page=2) are thin, near-duplicate views of /blog and were showing up as "crawled, currently not indexed" in Search Console. They now return noindex (still follow, so Google keeps discovering posts through them), while /blog itself stays indexed. Keeps my index focused on real content.