### PR TITLE
Add in-house newsletter (double opt-in, send-on-publish)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,10 @@ CLOUDINARY_API_SECRET=
 # the admin editor. Register a free app at unsplash.com/developers.
 # When unset, the Unsplash buttons are hidden.
 UNSPLASH_ACCESS_KEY=
+
+# Resend (newsletter emails). Get a key at resend.com and verify a sending domain.
+RESEND_API_KEY=
+# From address on your verified domain, e.g. "Sixtus Agbo <newsletter@sixtusagbo.dev>"
+NEWSLETTER_FROM=
+# Reply-To for newsletter emails (decoupled from ADMIN_EMAIL on purpose)
+NEWSLETTER_REPLY_TO=

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
+        "resend": "^6.14.0",
         "shiki": "^4.2.0",
         "unified": "^11.0.5"
       },
@@ -1815,6 +1816,12 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -4350,6 +4357,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -7580,6 +7593,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -7959,6 +7978,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.14.0.tgz",
+      "integrity": "sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -8373,6 +8413,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
+    "resend": "^6.14.0",
     "shiki": "^4.2.0",
     "unified": "^11.0.5"
   },

--- a/scripts/backfill-newsletter-sent.ts
+++ b/scripts/backfill-newsletter-sent.ts
@@ -1,0 +1,35 @@
+/**
+ * One-off: mark every already-published post as "newsletter already sent" so
+ * editing or re-saving an old post never emails it to subscribers. Drafts are
+ * left untouched, so a draft still goes out the first time it's published.
+ *
+ * Run once per database after deploying the newsletter:
+ *   - Local:  node --env-file=.env.local --import tsx scripts/backfill-newsletter-sent.ts
+ *   - Atlas:  npx tsx scripts/backfill-newsletter-sent.ts   (reads .env.production)
+ */
+
+import mongoose from "mongoose";
+import { Post } from "../src/lib/models/Post";
+import { loadEnv } from "./load-env";
+
+async function main(): Promise<void> {
+  loadEnv();
+  const uri = process.env.MONGODB_URI;
+  if (!uri) throw new Error("MONGODB_URI is not set");
+
+  await mongoose.connect(uri);
+  const result = await Post.updateMany(
+    { status: "published", newsletterSentAt: null },
+    [{ $set: { newsletterSentAt: { $ifNull: ["$publishedAt", "$createdAt"] } } }],
+    { updatePipeline: true }
+  );
+  console.log(
+    `Marked ${result.modifiedCount} published post(s) as already announced.`
+  );
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/load-env.ts
+++ b/scripts/load-env.ts
@@ -1,0 +1,22 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Minimal .env reader for one-off scripts. Loads the given files in order; the
+// first file to define a key wins, and anything already in process.env (e.g.
+// from `node --env-file`) is never overridden. Surrounding quotes are stripped.
+export function loadEnv(
+  files: string[] = [".env.production", ".env.local"]
+): void {
+  for (const file of files) {
+    const path = join(ROOT, file);
+    if (!existsSync(path)) continue;
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      const match = line.match(/^([A-Z_]+)=(.*)$/);
+      if (!match || process.env[match[1]]) continue;
+      process.env[match[1]] = match[2].replace(/^"(.*)"$/, "$1").trim();
+    }
+  }
+}

--- a/scripts/migrate-images-to-cloudinary.ts
+++ b/scripts/migrate-images-to-cloudinary.ts
@@ -27,21 +27,10 @@ import { fileURLToPath } from "node:url";
 import { v2 as cloudinary } from "cloudinary";
 import mongoose from "mongoose";
 import { Post } from "../src/lib/models/Post";
+import { loadEnv } from "./load-env";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const PUBLIC_DIR = join(ROOT, "public");
-
-function loadEnv(file: string): void {
-  const path = join(ROOT, file);
-  if (!existsSync(path)) return;
-  for (const line of readFileSync(path, "utf8").split("\n")) {
-    const match = line.match(/^([A-Z_]+)=(.*)$/);
-    if (!match) continue;
-    const [, key, rawVal] = match;
-    if (process.env[key]) continue; // first file wins
-    process.env[key] = rawVal.replace(/^"(.*)"$/, "$1").trim();
-  }
-}
 
 function walk(dir: string): string[] {
   if (!existsSync(dir)) return [];
@@ -91,8 +80,7 @@ function replaceAll(text: string, map: Map<string, string>): string {
 }
 
 async function main() {
-  loadEnv(".env.production");
-  loadEnv(".env.local");
+  loadEnv();
 
   const { MONGODB_URI, CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET } =
     process.env;

--- a/scripts/migrate-medium.ts
+++ b/scripts/migrate-medium.ts
@@ -25,26 +25,13 @@ import {
   excerptFromMarkdown,
   slugify,
 } from "../src/lib/utils";
+import { loadEnv } from "./load-env";
 
 const FEED_URL = "https://medium.com/feed/@sixtusagbo";
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 // Older posts the RSS feed no longer carries (it caps at 10), scraped from
 // the Medium post pages into JSON files
 const ARCHIVE_DIR = join(ROOT, "scripts", "data", "medium-archive");
-
-function loadEnvLocal(): void {
-  try {
-    const content = readFileSync(join(ROOT, ".env.local"), "utf8");
-    for (const line of content.split("\n")) {
-      const match = line.match(/^([A-Z_]+)=(.*)$/);
-      if (match && !process.env[match[1]]) {
-        process.env[match[1]] = match[2];
-      }
-    }
-  } catch {
-    // no .env.local; rely on the environment
-  }
-}
 
 type FeedItem = {
   title: string;
@@ -244,7 +231,7 @@ async function upsertPost(post: SourcePost): Promise<void> {
 }
 
 async function main() {
-  loadEnvLocal();
+  loadEnv([".env.local"]);
   const uri = process.env.MONGODB_URI;
   if (!uri) throw new Error("MONGODB_URI is not set");
 

--- a/src/app/(site)/blog/[slug]/page.tsx
+++ b/src/app/(site)/blog/[slug]/page.tsx
@@ -16,6 +16,8 @@ import CodeCopyButtons from "@/components/blog/CodeCopyButtons";
 import ReadingProgress from "@/components/blog/ReadingProgress";
 import ShareButtons from "@/components/blog/ShareButtons";
 import ViewTracker from "@/components/blog/ViewTracker";
+import NewsletterForm from "@/components/blog/NewsletterForm";
+import { newsletterEnabled } from "@/lib/email";
 
 export const revalidate = 3600;
 
@@ -271,6 +273,9 @@ export default async function BlogPostPage({ params }: { params: Params }) {
             </Link>
           </div>
         </div>
+
+        {/* Newsletter */}
+        {newsletterEnabled() && <NewsletterForm />}
 
         {/* Prev / Next */}
         {(adjacent.prev || adjacent.next) && (

--- a/src/app/(site)/blog/page.tsx
+++ b/src/app/(site)/blog/page.tsx
@@ -4,6 +4,8 @@ import { getAllTags, getPublishedPosts, type PostSort } from "@/lib/posts";
 import PostCard from "@/components/blog/PostCard";
 import BlogControls from "@/components/blog/BlogControls";
 import Pagination from "@/components/blog/Pagination";
+import NewsletterForm from "@/components/blog/NewsletterForm";
+import { newsletterEnabled } from "@/lib/email";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 
@@ -146,6 +148,8 @@ export default async function BlogPage({
             )}
           </div>
         </div>
+
+        {newsletterEnabled() && <NewsletterForm />}
       </div>
     </div>
   );

--- a/src/app/(site)/newsletter/actions.ts
+++ b/src/app/(site)/newsletter/actions.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { newsletterEnabled } from "@/lib/email";
+import { sendConfirmationEmail } from "@/lib/newsletter";
+import { isValidEmail, subscribe } from "@/lib/subscribers";
+
+export type SubscribeState = { ok: boolean; message: string } | null;
+
+export async function subscribeAction(
+  _prev: SubscribeState,
+  formData: FormData
+): Promise<SubscribeState> {
+  // Honeypot: bots fill the hidden field, humans never see it. Pretend success.
+  if (String(formData.get("company") ?? "").trim()) {
+    return { ok: true, message: "Thanks! Check your inbox to confirm." };
+  }
+
+  if (!newsletterEnabled()) {
+    return { ok: false, message: "The newsletter isn't available right now." };
+  }
+
+  const email = String(formData.get("email") ?? "")
+    .trim()
+    .toLowerCase();
+  if (!isValidEmail(email)) {
+    return { ok: false, message: "Please enter a valid email address." };
+  }
+
+  const result = await subscribe(email);
+  if (!result.ok) return { ok: false, message: result.error };
+
+  if (result.status === "confirmed") {
+    return { ok: true, message: "You're already subscribed. Thanks!" };
+  }
+
+  try {
+    await sendConfirmationEmail(email, result.token);
+  } catch {
+    return {
+      ok: false,
+      message: "Couldn't send the confirmation email. Please try again.",
+    };
+  }
+
+  return {
+    ok: true,
+    message: "Almost there! Check your inbox to confirm your subscription.",
+  };
+}

--- a/src/app/(site)/newsletter/page.tsx
+++ b/src/app/(site)/newsletter/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CheckCircle2, MailX, XCircle } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Newsletter",
+  robots: { index: false, follow: false },
+};
+
+type SearchParams = Promise<{ status?: string }>;
+
+const STATES = {
+  confirmed: {
+    icon: CheckCircle2,
+    accent: "text-emerald-400",
+    title: "You're subscribed!",
+    body: "Thanks for confirming. You'll get an email whenever I publish a new post.",
+  },
+  unsubscribed: {
+    icon: MailX,
+    accent: "text-neutral-300",
+    title: "You've unsubscribed",
+    body: "You won't receive any more newsletter emails. No hard feelings, you can resubscribe anytime.",
+  },
+  invalid: {
+    icon: XCircle,
+    accent: "text-red-400",
+    title: "That link didn't work",
+    body: "The link may have expired or already been used. Try subscribing again from the blog.",
+  },
+} as const;
+
+export default async function NewsletterPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const { status } = await searchParams;
+  const key =
+    status === "confirmed" || status === "unsubscribed" ? status : "invalid";
+  const { icon: Icon, accent, title, body } = STATES[key];
+
+  return (
+    <div className="pt-32 pb-20 min-h-[60vh] flex items-center">
+      <div className="max-w-lg mx-auto px-6 text-center space-y-6">
+        <Icon size={48} className={`mx-auto ${accent}`} />
+        <h1 className="text-3xl md:text-4xl font-bold">{title}</h1>
+        <p className="text-neutral-400 leading-relaxed">{body}</p>
+        <Link
+          href="/blog"
+          className="inline-block px-6 py-3 bg-white text-neutral-950 rounded-full font-semibold hover:bg-neutral-200 transition-colors">
+          Back to the blog
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(panel)/page.tsx
+++ b/src/app/admin/(panel)/page.tsx
@@ -1,13 +1,18 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowUpRight, Eye, FileText, NotebookPen, Send } from "lucide-react";
+import { ArrowUpRight, Eye, FileText, Mail, NotebookPen, Send } from "lucide-react";
 import { adminListPosts, getStats } from "@/lib/posts";
+import { getSubscriberStats } from "@/lib/subscribers";
 import { formatDate } from "@/lib/utils";
 
 export const metadata: Metadata = { title: "Dashboard" };
 
 export default async function AdminDashboard() {
-  const [stats, posts] = await Promise.all([getStats(), adminListPosts()]);
+  const [stats, posts, subscribers] = await Promise.all([
+    getStats(),
+    adminListPosts(),
+    getSubscriberStats(),
+  ]);
   const recent = posts.slice(0, 5);
 
   const cards = [
@@ -15,6 +20,7 @@ export default async function AdminDashboard() {
     { label: "Published", value: stats.published, icon: Send },
     { label: "Drafts", value: stats.drafts, icon: NotebookPen },
     { label: "Total Views", value: stats.totalViews, icon: Eye },
+    { label: "Subscribers", value: subscribers.confirmed, icon: Mail },
   ];
 
   return (
@@ -34,7 +40,7 @@ export default async function AdminDashboard() {
         </Link>
       </div>
 
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
         {cards.map(({ label, value, icon: Icon }) => (
           <div
             key={label}

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -22,6 +22,22 @@ import {
   deleteCloudinaryImages,
   findCloudinaryUrls,
 } from "@/lib/cloudinary-server";
+import { notifySubscribersOfPost } from "@/lib/newsletter";
+
+// Email subscribers about a freshly published post. Safe to call on every
+// published save: it only sends on the first publish and never blocks the
+// editor if email delivery hiccups.
+async function announceIfPublished(
+  id: string,
+  status: "draft" | "published"
+): Promise<void> {
+  if (status !== "published") return;
+  try {
+    await notifySubscribersOfPost(id);
+  } catch {
+    // Delivery problems must not fail the save/publish itself.
+  }
+}
 
 // Delete the given Cloudinary images, skipping any still used by another post.
 async function cleanupImages(
@@ -110,6 +126,7 @@ export async function savePostAction(
     }
 
     revalidateBlog([saved.slug, previous?.slug]);
+    await announceIfPublished(saved.id, saved.status);
     return { ok: true, id: saved.id, slug: saved.slug };
   } catch (error) {
     if (
@@ -152,6 +169,7 @@ export async function setPostStatusAction(
   }
   const saved = await updatePost(id, { ...post, status });
   revalidateBlog([saved?.slug ?? post.slug]);
+  await announceIfPublished(id, status);
   return { ok: true };
 }
 

--- a/src/app/api/newsletter/confirm/route.ts
+++ b/src/app/api/newsletter/confirm/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { confirmSubscriber } from "@/lib/subscribers";
+
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token") ?? "";
+  const ok = await confirmSubscriber(token);
+
+  const url = new URL("/newsletter", request.nextUrl.origin);
+  url.searchParams.set("status", ok ? "confirmed" : "invalid");
+  return NextResponse.redirect(url);
+}

--- a/src/app/api/newsletter/unsubscribe/route.ts
+++ b/src/app/api/newsletter/unsubscribe/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { unsubscribeByToken } from "@/lib/subscribers";
+
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token") ?? "";
+  const ok = await unsubscribeByToken(token);
+
+  const url = new URL("/newsletter", request.nextUrl.origin);
+  url.searchParams.set("status", ok ? "unsubscribed" : "invalid");
+  return NextResponse.redirect(url);
+}
+
+// One-click unsubscribe (RFC 8058): Gmail/Apple Mail POST here directly from
+// the List-Unsubscribe header, no page visit involved.
+export async function POST(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token") ?? "";
+  await unsubscribeByToken(token);
+  return new NextResponse(null, { status: 200 });
+}

--- a/src/components/blog/NewsletterForm.tsx
+++ b/src/components/blog/NewsletterForm.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useActionState } from "react";
+import { CheckCircle2, Loader2, Mail } from "lucide-react";
+import {
+  subscribeAction,
+  type SubscribeState,
+} from "@/app/(site)/newsletter/actions";
+
+export default function NewsletterForm() {
+  const [state, formAction, isPending] = useActionState<
+    SubscribeState,
+    FormData
+  >(subscribeAction, null);
+
+  return (
+    <section className="bg-neutral-900 border border-neutral-800 rounded-3xl p-8 md:p-10">
+      <div className="flex items-start gap-4 mb-6">
+        <div className="hidden sm:flex w-11 h-11 rounded-2xl bg-neutral-800 items-center justify-center flex-shrink-0">
+          <Mail size={20} className="text-neutral-300" />
+        </div>
+        <div className="space-y-1.5">
+          <h2 className="text-xl md:text-2xl font-bold">
+            Subscribe to the newsletter
+          </h2>
+          <p className="text-sm text-neutral-400 max-w-md">
+            New posts on web &amp; mobile development, straight to your inbox. No
+            spam, unsubscribe anytime.
+          </p>
+        </div>
+      </div>
+
+      {state?.ok ? (
+        <p className="flex items-center gap-2 text-sm text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 rounded-xl px-4 py-3">
+          <CheckCircle2 size={16} className="flex-shrink-0" />
+          {state.message}
+        </p>
+      ) : (
+        <form action={formAction} className="space-y-3">
+          {/* Honeypot: hidden from humans, catches bots. */}
+          <input
+            type="text"
+            name="company"
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+            className="hidden"
+          />
+          <div className="flex flex-col sm:flex-row gap-3">
+            <input
+              type="email"
+              name="email"
+              required
+              autoComplete="email"
+              placeholder="you@example.com"
+              aria-label="Email address"
+              className="flex-1 bg-neutral-800 border border-neutral-700 rounded-full px-5 py-3 text-sm focus:outline-none focus:border-neutral-500 placeholder-neutral-500"
+            />
+            <button
+              type="submit"
+              disabled={isPending}
+              className="flex items-center justify-center gap-2 px-6 py-3 bg-white text-neutral-950 rounded-full text-sm font-semibold hover:bg-neutral-200 transition-colors disabled:opacity-60">
+              {isPending && <Loader2 size={16} className="animate-spin" />}
+              Subscribe
+            </button>
+          </div>
+          {state && !state.ok && (
+            <p className="text-sm text-red-400">{state.message}</p>
+          )}
+        </form>
+      )}
+    </section>
+  );
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,81 @@
+import { Resend } from "resend";
+
+// The newsletter is fully optional: with no key/from it stays dormant and the
+// signup UI is hidden, exactly like the Cloudinary/Unsplash integrations.
+export function newsletterEnabled(): boolean {
+  return Boolean(process.env.RESEND_API_KEY && process.env.NEWSLETTER_FROM);
+}
+
+let client: Resend | null = null;
+
+function getClient(): Resend {
+  const key = process.env.RESEND_API_KEY;
+  if (!key) throw new Error("RESEND_API_KEY is not set");
+  client ??= new Resend(key);
+  return client;
+}
+
+function fromAddress(): string {
+  const value = process.env.NEWSLETTER_FROM;
+  if (!value) throw new Error("NEWSLETTER_FROM is not set");
+  return value;
+}
+
+function replyTo(): string | undefined {
+  return process.env.NEWSLETTER_REPLY_TO || undefined;
+}
+
+export type EmailMessage = {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+  headers?: Record<string, string>;
+};
+
+export async function sendEmail(message: EmailMessage): Promise<void> {
+  const { error } = await getClient().emails.send({
+    from: fromAddress(),
+    to: message.to,
+    subject: message.subject,
+    html: message.html,
+    text: message.text,
+    replyTo: replyTo(),
+    headers: message.headers,
+  });
+  if (error) throw new Error(error.message);
+}
+
+// Send many emails through Resend's batch endpoint (max 100 per call), so a
+// large list stays well under the API rate limit. Returns how many went out.
+export async function sendEmails(
+  messages: EmailMessage[]
+): Promise<{ sent: number; failed: number }> {
+  const reply = replyTo();
+  const from = fromAddress();
+  let sent = 0;
+  let failed = 0;
+
+  for (let i = 0; i < messages.length; i += 100) {
+    const chunk = messages.slice(i, i + 100);
+    try {
+      const { error } = await getClient().batch.send(
+        chunk.map((m) => ({
+          from,
+          to: m.to,
+          subject: m.subject,
+          html: m.html,
+          text: m.text,
+          replyTo: reply,
+          headers: m.headers,
+        }))
+      );
+      if (error) failed += chunk.length;
+      else sent += chunk.length;
+    } catch {
+      failed += chunk.length;
+    }
+  }
+
+  return { sent, failed };
+}

--- a/src/lib/models/Post.ts
+++ b/src/lib/models/Post.ts
@@ -28,6 +28,9 @@ const postSchema = new Schema(
     publishedAt: { type: Date, default: null },
     readingTime: { type: Number, default: 1 },
     views: { type: Number, default: 0 },
+    // Stamped the first time a published post is emailed to subscribers, so it
+    // never goes out twice on re-saves or re-publishes.
+    newsletterSentAt: { type: Date, default: null },
   },
   { timestamps: true }
 );

--- a/src/lib/models/Subscriber.ts
+++ b/src/lib/models/Subscriber.ts
@@ -1,0 +1,33 @@
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+} from "mongoose";
+
+const subscriberSchema = new Schema(
+  {
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+    },
+    status: {
+      type: String,
+      enum: ["pending", "confirmed", "unsubscribed"],
+      default: "pending",
+    },
+    // Random, unguessable token used for both the confirm and unsubscribe links.
+    token: { type: String, required: true, index: true },
+    confirmedAt: { type: Date, default: null },
+  },
+  { timestamps: true }
+);
+
+export type SubscriberDoc = InferSchemaType<typeof subscriberSchema>;
+
+export const Subscriber: Model<SubscriberDoc> =
+  models.Subscriber ?? model("Subscriber", subscriberSchema);

--- a/src/lib/newsletter-templates.ts
+++ b/src/lib/newsletter-templates.ts
@@ -1,0 +1,96 @@
+import { SITE_URL } from "@/config/constants";
+import type { BlogPost } from "./posts";
+
+const BRAND = "Sixtus Agbo";
+
+export type BuiltEmail = { subject: string; html: string; text: string };
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// Wraps content in the branded shell: a wordmark, a white rounded card, and a
+// muted footer, all inline-styled so it renders consistently across clients.
+function layout(cardRows: string, footerHtml: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f4f4f5;-webkit-font-smoothing:antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:28px 12px;">
+    <tr><td align="center">
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+        <tr><td style="padding:2px 6px 16px;">
+          <a href="${SITE_URL}" style="font-size:18px;font-weight:700;letter-spacing:-.02em;color:#0a0a0a;text-decoration:none;">Sixtus&nbsp;Agbo</a>
+        </td></tr>
+        <tr><td style="background:#ffffff;border:1px solid #e4e4e7;border-radius:16px;overflow:hidden;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="color:#18181b;">
+            ${cardRows}
+          </table>
+        </td></tr>
+        <tr><td style="padding:18px 8px 4px;">${footerHtml}</td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}
+
+function eyebrow(text: string): string {
+  return `<p style="margin:0 0 8px;font-size:12px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#71717a;">${text}</p>`;
+}
+
+function button(href: string, label: string): string {
+  return `<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:9999px;background:#0a0a0a;">
+    <a href="${href}" style="display:inline-block;padding:13px 30px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:9999px;">${label}</a>
+  </td></tr></table>`;
+}
+
+export function buildConfirmationEmail(confirmUrl: string): BuiltEmail {
+  const card = `
+    <tr><td style="padding:34px 34px 30px;">
+      ${eyebrow("Confirm your subscription")}
+      <h1 style="margin:0 0 14px;font-size:23px;line-height:1.3;color:#0a0a0a;">One quick step</h1>
+      <p style="margin:0 0 24px;font-size:15px;line-height:1.65;color:#3f3f46;">Confirm your email to start getting new posts on web &amp; mobile development from ${BRAND}, straight to your inbox. No spam, unsubscribe anytime.</p>
+      ${button(confirmUrl, "Confirm subscription")}
+      <p style="margin:24px 0 0;font-size:13px;line-height:1.6;color:#a1a1aa;">Button not working? Paste this into your browser:<br><a href="${confirmUrl}" style="color:#71717a;word-break:break-all;">${confirmUrl}</a></p>
+    </td></tr>`;
+
+  const footer = `<p style="margin:0;font-size:12px;line-height:1.6;color:#a1a1aa;">You received this because this address was entered at <a href="${SITE_URL}/blog" style="color:#71717a;">sixtusagbo.dev</a>. If that wasn't you, just ignore this email.</p>`;
+
+  return {
+    subject: `Confirm your subscription to ${BRAND}`,
+    html: layout(card, footer),
+    text: `Confirm your subscription to ${BRAND}'s newsletter:\n${confirmUrl}\n\nIf you didn't sign up, ignore this email.`,
+  };
+}
+
+export function buildPostEmail(
+  post: Pick<BlogPost, "title" | "excerpt" | "coverImage" | "readingTime">,
+  postUrl: string,
+  unsubscribeUrl: string
+): BuiltEmail {
+  const cover = post.coverImage
+    ? `<tr><td style="padding:0;"><a href="${postUrl}"><img src="${post.coverImage}" alt="" width="560" style="display:block;width:100%;max-width:560px;border:0;"></a></td></tr>`
+    : "";
+
+  const card = `
+    ${cover}
+    <tr><td style="padding:30px 34px 28px;">
+      ${eyebrow(`New post &middot; ${post.readingTime} min read`)}
+      <h1 style="margin:0 0 14px;font-size:25px;line-height:1.3;"><a href="${postUrl}" style="color:#0a0a0a;text-decoration:none;">${escapeHtml(post.title)}</a></h1>
+      <p style="margin:0 0 26px;font-size:15px;line-height:1.7;color:#3f3f46;">${escapeHtml(post.excerpt)}</p>
+      ${button(postUrl, "Read the full post")}
+    </td></tr>`;
+
+  const footer = `<p style="margin:0;font-size:12px;line-height:1.6;color:#a1a1aa;">You're getting this because you subscribed at <a href="${SITE_URL}/blog" style="color:#71717a;">sixtusagbo.dev</a>.<br><a href="${unsubscribeUrl}" style="color:#71717a;text-decoration:underline;">Unsubscribe</a></p>`;
+
+  return {
+    subject: post.title,
+    html: layout(card, footer),
+    text: `New post from ${BRAND}\n\n${post.title}\n\n${post.excerpt}\n\nRead it: ${postUrl}\n\n—\nUnsubscribe: ${unsubscribeUrl}`,
+  };
+}

--- a/src/lib/newsletter-templates.ts
+++ b/src/lib/newsletter-templates.ts
@@ -23,9 +23,6 @@ function layout(cardRows: string, footerHtml: string): string {
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:28px 12px;">
     <tr><td align="center">
       <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
-        <tr><td style="padding:2px 6px 16px;">
-          <a href="${SITE_URL}" style="font-size:18px;font-weight:700;letter-spacing:-.02em;color:#0a0a0a;text-decoration:none;">Sixtus&nbsp;Agbo</a>
-        </td></tr>
         <tr><td style="background:#ffffff;border:1px solid #e4e4e7;border-radius:16px;overflow:hidden;">
           <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="color:#18181b;">
             ${cardRows}

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -6,42 +6,8 @@ import {
   type EmailMessage,
 } from "./email";
 import { getConfirmedSubscribers } from "./subscribers";
-import {
-  claimNewsletterSend,
-  releaseNewsletterSend,
-  type BlogPost,
-} from "./posts";
-
-const BRAND = "Sixtus Agbo";
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-function shell(inner: string): string {
-  return `<!doctype html>
-<html lang="en">
-<body style="margin:0;padding:0;background:#f4f4f5;">
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 12px;">
-    <tr><td align="center">
-      <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;width:100%;background:#ffffff;border:1px solid #e4e4e7;border-radius:16px;overflow:hidden;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#18181b;">
-        ${inner}
-      </table>
-    </td></tr>
-  </table>
-</body>
-</html>`;
-}
-
-function button(href: string, label: string): string {
-  return `<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:9999px;background:#0a0a0a;">
-    <a href="${href}" style="display:inline-block;padding:13px 28px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:9999px;">${label}</a>
-  </td></tr></table>`;
-}
+import { claimNewsletterSend, releaseNewsletterSend } from "./posts";
+import { buildConfirmationEmail, buildPostEmail } from "./newsletter-templates";
 
 export async function sendConfirmationEmail(
   email: string,
@@ -49,55 +15,8 @@ export async function sendConfirmationEmail(
 ): Promise<void> {
   const base = await getBaseUrl();
   const confirmUrl = `${base}/api/newsletter/confirm?token=${token}`;
-
-  const html = shell(`
-    <tr><td style="padding:36px 36px 28px;">
-      <p style="margin:0 0 6px;font-size:13px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:#71717a;">${BRAND}</p>
-      <h1 style="margin:0 0 14px;font-size:22px;line-height:1.3;">Confirm your subscription</h1>
-      <p style="margin:0 0 22px;font-size:15px;line-height:1.6;color:#3f3f46;">Click below to confirm you'd like new posts on web &amp; mobile development delivered to your inbox.</p>
-      ${button(confirmUrl, "Confirm subscription")}
-      <p style="margin:22px 0 0;font-size:13px;line-height:1.6;color:#a1a1aa;">If you didn't sign up, you can safely ignore this email.</p>
-    </td></tr>`);
-
-  const text = `Confirm your subscription to ${BRAND}'s newsletter:\n${confirmUrl}\n\nIf you didn't sign up, ignore this email.`;
-
-  await sendEmail({
-    to: email,
-    subject: `Confirm your subscription to ${BRAND}`,
-    html,
-    text,
-  });
-}
-
-function postEmailHtml(
-  post: BlogPost,
-  postUrl: string,
-  unsubscribeUrl: string
-): string {
-  const cover = post.coverImage
-    ? `<tr><td style="padding:0;"><a href="${postUrl}"><img src="${post.coverImage}" alt="" width="560" style="display:block;width:100%;max-width:560px;border:0;"></a></td></tr>`
-    : "";
-
-  return shell(`
-    ${cover}
-    <tr><td style="padding:32px 36px 28px;">
-      <p style="margin:0 0 8px;font-size:13px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:#71717a;">New post &middot; ${BRAND}</p>
-      <h1 style="margin:0 0 14px;font-size:24px;line-height:1.3;"><a href="${postUrl}" style="color:#0a0a0a;text-decoration:none;">${escapeHtml(post.title)}</a></h1>
-      <p style="margin:0 0 24px;font-size:15px;line-height:1.65;color:#3f3f46;">${escapeHtml(post.excerpt)}</p>
-      ${button(postUrl, "Read the full post")}
-    </td></tr>
-    <tr><td style="padding:0 36px;"><hr style="border:none;border-top:1px solid #e4e4e7;margin:0;"></td></tr>
-    <tr><td style="padding:20px 36px 32px;">
-      <p style="margin:0;font-size:12px;line-height:1.6;color:#a1a1aa;">You're receiving this because you subscribed at sixtusagbo.dev.<br><a href="${unsubscribeUrl}" style="color:#71717a;text-decoration:underline;">Unsubscribe</a></p>
-    </td></tr>`);
-}
-
-function postEmailText(
-  post: BlogPost,
-  postUrl: string,
-  unsubscribeUrl: string
-): string {
-  return `New post from ${BRAND}\n\n${post.title}\n\n${post.excerpt}\n\nRead it: ${postUrl}\n\n—\nUnsubscribe: ${unsubscribeUrl}`;
+  const { subject, html, text } = buildConfirmationEmail(confirmUrl);
+  await sendEmail({ to: email, subject, html, text });
 }
 
 // Email confirmed subscribers about a newly published post. Idempotent: the
@@ -120,11 +39,12 @@ export async function notifySubscribersOfPost(
 
   const messages: EmailMessage[] = subscribers.map(({ email, token }) => {
     const unsubscribeUrl = `${base}/api/newsletter/unsubscribe?token=${token}`;
+    const built = buildPostEmail(post, postUrl, unsubscribeUrl);
     return {
       to: email,
-      subject: post.title,
-      html: postEmailHtml(post, postUrl, unsubscribeUrl),
-      text: postEmailText(post, postUrl, unsubscribeUrl),
+      subject: built.subject,
+      html: built.html,
+      text: built.text,
       headers: {
         "List-Unsubscribe": `<${unsubscribeUrl}>`,
         "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -1,0 +1,140 @@
+import { getBaseUrl } from "./url";
+import {
+  newsletterEnabled,
+  sendEmail,
+  sendEmails,
+  type EmailMessage,
+} from "./email";
+import { getConfirmedSubscribers } from "./subscribers";
+import {
+  claimNewsletterSend,
+  releaseNewsletterSend,
+  type BlogPost,
+} from "./posts";
+
+const BRAND = "Sixtus Agbo";
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function shell(inner: string): string {
+  return `<!doctype html>
+<html lang="en">
+<body style="margin:0;padding:0;background:#f4f4f5;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 12px;">
+    <tr><td align="center">
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;width:100%;background:#ffffff;border:1px solid #e4e4e7;border-radius:16px;overflow:hidden;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#18181b;">
+        ${inner}
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}
+
+function button(href: string, label: string): string {
+  return `<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:9999px;background:#0a0a0a;">
+    <a href="${href}" style="display:inline-block;padding:13px 28px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:9999px;">${label}</a>
+  </td></tr></table>`;
+}
+
+export async function sendConfirmationEmail(
+  email: string,
+  token: string
+): Promise<void> {
+  const base = await getBaseUrl();
+  const confirmUrl = `${base}/api/newsletter/confirm?token=${token}`;
+
+  const html = shell(`
+    <tr><td style="padding:36px 36px 28px;">
+      <p style="margin:0 0 6px;font-size:13px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:#71717a;">${BRAND}</p>
+      <h1 style="margin:0 0 14px;font-size:22px;line-height:1.3;">Confirm your subscription</h1>
+      <p style="margin:0 0 22px;font-size:15px;line-height:1.6;color:#3f3f46;">Click below to confirm you'd like new posts on web &amp; mobile development delivered to your inbox.</p>
+      ${button(confirmUrl, "Confirm subscription")}
+      <p style="margin:22px 0 0;font-size:13px;line-height:1.6;color:#a1a1aa;">If you didn't sign up, you can safely ignore this email.</p>
+    </td></tr>`);
+
+  const text = `Confirm your subscription to ${BRAND}'s newsletter:\n${confirmUrl}\n\nIf you didn't sign up, ignore this email.`;
+
+  await sendEmail({
+    to: email,
+    subject: `Confirm your subscription to ${BRAND}`,
+    html,
+    text,
+  });
+}
+
+function postEmailHtml(
+  post: BlogPost,
+  postUrl: string,
+  unsubscribeUrl: string
+): string {
+  const cover = post.coverImage
+    ? `<tr><td style="padding:0;"><a href="${postUrl}"><img src="${post.coverImage}" alt="" width="560" style="display:block;width:100%;max-width:560px;border:0;"></a></td></tr>`
+    : "";
+
+  return shell(`
+    ${cover}
+    <tr><td style="padding:32px 36px 28px;">
+      <p style="margin:0 0 8px;font-size:13px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:#71717a;">New post &middot; ${BRAND}</p>
+      <h1 style="margin:0 0 14px;font-size:24px;line-height:1.3;"><a href="${postUrl}" style="color:#0a0a0a;text-decoration:none;">${escapeHtml(post.title)}</a></h1>
+      <p style="margin:0 0 24px;font-size:15px;line-height:1.65;color:#3f3f46;">${escapeHtml(post.excerpt)}</p>
+      ${button(postUrl, "Read the full post")}
+    </td></tr>
+    <tr><td style="padding:0 36px;"><hr style="border:none;border-top:1px solid #e4e4e7;margin:0;"></td></tr>
+    <tr><td style="padding:20px 36px 32px;">
+      <p style="margin:0;font-size:12px;line-height:1.6;color:#a1a1aa;">You're receiving this because you subscribed at sixtusagbo.dev.<br><a href="${unsubscribeUrl}" style="color:#71717a;text-decoration:underline;">Unsubscribe</a></p>
+    </td></tr>`);
+}
+
+function postEmailText(
+  post: BlogPost,
+  postUrl: string,
+  unsubscribeUrl: string
+): string {
+  return `New post from ${BRAND}\n\n${post.title}\n\n${post.excerpt}\n\nRead it: ${postUrl}\n\n—\nUnsubscribe: ${unsubscribeUrl}`;
+}
+
+// Email confirmed subscribers about a newly published post. Idempotent: the
+// first call claims the post (stamping newsletterSentAt) so re-saving or
+// re-publishing never sends twice. A total send failure releases the claim so
+// a later publish can retry.
+export async function notifySubscribersOfPost(
+  postId: string
+): Promise<{ sent: number; failed: number }> {
+  if (!newsletterEnabled()) return { sent: 0, failed: 0 };
+
+  const post = await claimNewsletterSend(postId);
+  if (!post) return { sent: 0, failed: 0 };
+
+  const subscribers = await getConfirmedSubscribers();
+  if (subscribers.length === 0) return { sent: 0, failed: 0 };
+
+  const base = await getBaseUrl();
+  const postUrl = `${base}/blog/${post.slug}?utm_source=newsletter&utm_medium=email`;
+
+  const messages: EmailMessage[] = subscribers.map(({ email, token }) => {
+    const unsubscribeUrl = `${base}/api/newsletter/unsubscribe?token=${token}`;
+    return {
+      to: email,
+      subject: post.title,
+      html: postEmailHtml(post, postUrl, unsubscribeUrl),
+      text: postEmailText(post, postUrl, unsubscribeUrl),
+      headers: {
+        "List-Unsubscribe": `<${unsubscribeUrl}>`,
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
+    };
+  });
+
+  const result = await sendEmails(messages);
+  if (result.sent === 0 && result.failed > 0) {
+    await releaseNewsletterSend(postId);
+  }
+  return result;
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -22,6 +22,7 @@ export type BlogPost = {
   updatedAt: string;
   readingTime: number;
   views: number;
+  newsletterSentAt: string | null;
 };
 
 export type PostSort = "newest" | "oldest" | "title";
@@ -72,6 +73,9 @@ function serialize(doc: LeanPost): BlogPost {
     updatedAt: doc.updatedAt?.toISOString() ?? "",
     readingTime: doc.readingTime ?? 1,
     views: doc.views ?? 0,
+    newsletterSentAt: doc.newsletterSentAt
+      ? doc.newsletterSentAt.toISOString()
+      : null,
   };
 }
 
@@ -200,6 +204,27 @@ export async function getAllPublishedSlugs(): Promise<
 export async function incrementViews(slug: string): Promise<void> {
   await connectDB();
   await Post.updateOne({ slug, status: "published" }, { $inc: { views: 1 } });
+}
+
+// Atomically claim the right to email subscribers about this post. Returns the
+// post only on the first published, not-yet-sent call; null otherwise. This
+// guards against duplicate sends when a published post is saved again.
+export async function claimNewsletterSend(
+  id: string
+): Promise<BlogPost | null> {
+  await connectDB();
+  const doc = await Post.findOneAndUpdate(
+    { _id: id, status: "published", newsletterSentAt: null },
+    { $set: { newsletterSentAt: new Date() } },
+    { new: true }
+  ).lean<LeanPost>();
+  return doc ? serialize(doc) : null;
+}
+
+// Undo a claim so a later publish can retry (used when sending fails entirely).
+export async function releaseNewsletterSend(id: string): Promise<void> {
+  await connectDB();
+  await Post.updateOne({ _id: id }, { $set: { newsletterSentAt: null } });
 }
 
 // Admin queries

--- a/src/lib/subscribers.ts
+++ b/src/lib/subscribers.ts
@@ -1,0 +1,86 @@
+import { randomBytes } from "node:crypto";
+import { connectDB } from "./db";
+import { Subscriber } from "./models/Subscriber";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_RE.test(email);
+}
+
+function newToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export type SubscribeResult =
+  | { ok: true; status: "pending" | "confirmed"; token: string }
+  | { ok: false; error: string };
+
+// Create a new pending subscriber, or revive a previously unsubscribed/pending
+// one with a fresh token. An already-confirmed address is left untouched.
+export async function subscribe(rawEmail: string): Promise<SubscribeResult> {
+  const email = rawEmail.trim().toLowerCase();
+  if (!isValidEmail(email)) {
+    return { ok: false, error: "Please enter a valid email address." };
+  }
+
+  await connectDB();
+  const existing = await Subscriber.findOne({ email });
+
+  if (existing?.status === "confirmed") {
+    return { ok: true, status: "confirmed", token: existing.token };
+  }
+
+  const token = newToken();
+  if (existing) {
+    existing.status = "pending";
+    existing.token = token;
+    existing.confirmedAt = null;
+    await existing.save();
+  } else {
+    await Subscriber.create({ email, token, status: "pending" });
+  }
+  return { ok: true, status: "pending", token };
+}
+
+export async function confirmSubscriber(token: string): Promise<boolean> {
+  if (!token) return false;
+  await connectDB();
+  const doc = await Subscriber.findOneAndUpdate(
+    { token, status: { $ne: "unsubscribed" } },
+    { $set: { status: "confirmed", confirmedAt: new Date() } }
+  );
+  return Boolean(doc);
+}
+
+export async function unsubscribeByToken(token: string): Promise<boolean> {
+  if (!token) return false;
+  await connectDB();
+  const doc = await Subscriber.findOneAndUpdate(
+    { token },
+    { $set: { status: "unsubscribed" } }
+  );
+  return Boolean(doc);
+}
+
+export async function getConfirmedSubscribers(): Promise<
+  { email: string; token: string }[]
+> {
+  await connectDB();
+  const docs = await Subscriber.find({ status: "confirmed" })
+    .select("email token")
+    .lean<{ email: string; token: string }[]>();
+  return docs.map((d) => ({ email: d.email, token: d.token }));
+}
+
+export async function getSubscriberStats(): Promise<{
+  confirmed: number;
+  pending: number;
+}> {
+  await connectDB();
+  const [confirmed, pending] = await Promise.all([
+    Subscriber.countDocuments({ status: "confirmed" }),
+    Subscriber.countDocuments({ status: "pending" }),
+  ]);
+  return { confirmed, pending };
+}

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,23 @@
+import { headers } from "next/headers";
+import { SITE_URL } from "@/config/constants";
+
+// Absolute base URL for links embedded in emails. Derived from the incoming
+// request host so confirm/unsubscribe links point at localhost in dev and the
+// real domain in production, without an extra env var.
+export async function getBaseUrl(): Promise<string> {
+  try {
+    const h = await headers();
+    const host = h.get("host");
+    if (host) {
+      const proto =
+        h.get("x-forwarded-proto") ??
+        (host.startsWith("localhost") || host.startsWith("127.0.0.1")
+          ? "http"
+          : "https");
+      return `${proto}://${host}`;
+    }
+  } catch {
+    // headers() is unavailable outside a request scope; fall back below.
+  }
+  return SITE_URL;
+}


### PR DESCRIPTION
## What

Adds an in-house newsletter to my blog: double opt-in subscribe, automatic
send-on-publish to confirmed subscribers, and one-click unsubscribe. No
third-party widget, sending runs through Resend on my verified
`mail.sixtusagbo.dev` domain.

## How it works

- Signup form on `/blog` and under every post (hidden unless Resend is configured).
- Subscribe -> confirmation email -> confirmed (double opt-in). Honeypot field
  catches bots.
- Publishing a post emails confirmed subscribers once. A `newsletterSentAt`
  stamp makes it idempotent, so re-saving a published post never re-sends; a
  total send failure clears the stamp so the next publish retries.
- One-click unsubscribe via the `List-Unsubscribe` / `List-Unsubscribe-Post`
  headers (RFC 8058), plus a normal unsubscribe link.
- From `Sixtus Agbo <sixtus@mail.sixtusagbo.dev>`, Reply-To my Gmail (a separate
  env var, decoupled from the admin login email).
- Branded HTML email templates (wordmark, white card, cover image, CTA button,
  footer), pulled into their own module so they're reusable and testable.
- Admin dashboard shows the confirmed-subscriber count.

## Notes

- New env vars: `RESEND_API_KEY`, `NEWSLETTER_FROM`, `NEWSLETTER_REPLY_TO`
  (added to `.env.example`). The feature self-disables when they're unset.
- One-time migration `scripts/backfill-newsletter-sent.ts` marks existing
  published posts as already-announced so editing an old post can't blast it.
  Must be run once against Atlas after deploy (drafts are left untouched).
- Also deduped the `.env` loader shared by the migration scripts.

## Verification

- `tsc --noEmit` and `eslint` clean (only pre-existing warnings).
- 11 DB tests pass (subscribe/confirm/unsubscribe/revive/validation), test data
  cleaned up.
- Confirm/unsubscribe/invalid routes and one-click POST verified against a live
  dev server; signup form and status page render.
- Real confirmation + new-post emails sent and received; Reply-To works.
